### PR TITLE
fix(extension): stabilize keyboard selection

### DIFF
--- a/docs/releases/float/float-v0.4.4.md
+++ b/docs/releases/float/float-v0.4.4.md
@@ -1,0 +1,32 @@
+### 更新摘要
+
+- 修复来源、域名、邮箱账号等自定义选择器在快速键盘操作时可能仍提交旧选项的问题。
+- 包含 `0.4.3` 的通知跳转修复：点击新邮件通知进入 OmniMail Web 收件箱，不再打开
+  `chrome-extension://.../panel.html#inbox`。
+
+### 修复
+
+- 选择器使用同步活动项引用处理方向键、Home、End、Enter 和空格；即使 React 尚未完成
+  下一次渲染，确认操作也会提交用户最后移动到的选项。
+- Linux CI 中连续 `ArrowDown → Enter` 不再偶发停留在原邮箱域名。
+- 通知点击会打开或激活用户配置的 `/mail/inbox`，不会覆盖草稿或设置标签。
+
+### 安全
+
+- 不新增 Chrome 权限；通知标签查询只限定用户配置的 OmniMail 主机。
+- Web/API、设备 Scope、第三方凭据边界和远程代码声明均没有变化。
+
+### 兼容性
+
+- 需要 Chrome 120 或更高版本。
+- 兼容 OmniMail Web/API `0.10.2` 或更高版本，不需要 Web/API 发版。
+
+### 安装与升级
+
+- 快速迭代阶段仅发布 GitHub Release ZIP，不上传 Chrome Web Store。
+- `0.4.2` 或 `0.4.3` 可以直接覆盖升级，不需要重新授权或接受新权限。
+
+### 测试
+
+- 通过 604 项单元测试、TypeScript、Oxlint、扩展生产构建和真实 Chromium smoke test。
+- Release CI 覆盖连续键盘选择、通知导航、八来源收件和会话恢复。

--- a/extension/public/manifest.json
+++ b/extension/public/manifest.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": 3,
   "name": "OmniMail Float",
-  "version": "0.4.3",
+  "version": "0.4.4",
   "minimum_chrome_version": "120",
   "description": "在任意网页生成邮箱地址，并查看 OmniMail、iCloud、Linux DO、Gmail、Microsoft、QQ、NAVER 与 Yandex 来信。",
   "icons": {

--- a/extension/src/PanelSelect.tsx
+++ b/extension/src/PanelSelect.tsx
@@ -18,6 +18,7 @@ interface Props {
 export function PanelSelect({ ariaLabel, disabled = false, id, onChange, options, value }: Props) {
   const [open, setOpen] = useState(false)
   const [activeIndex, setActiveIndex] = useState(0)
+  const activeIndexRef = useRef(0)
   const rootRef = useRef<HTMLDivElement>(null)
   const selectedIndex = Math.max(0, options.findIndex((option) => option.value === value))
   const selectedOption = options[selectedIndex]
@@ -30,11 +31,16 @@ export function PanelSelect({ ariaLabel, disabled = false, id, onChange, options
     }
     document.addEventListener('pointerdown', closeOnOutsideClick)
     return () => document.removeEventListener('pointerdown', closeOnOutsideClick)
-  }, [open, selectedIndex])
+  }, [open])
 
   useEffect(() => {
     if (unavailable) setOpen(false)
   }, [unavailable])
+
+  function activate(index: number) {
+    activeIndexRef.current = index
+    setActiveIndex(index)
+  }
 
   function select(index: number) {
     const option = options[index]
@@ -48,23 +54,24 @@ export function PanelSelect({ ariaLabel, disabled = false, id, onChange, options
     if (event.key === 'ArrowDown' || event.key === 'ArrowUp') {
       event.preventDefault()
       setOpen(true)
-      setActiveIndex((current) => {
-        if (!open) return selectedIndex
-        return event.key === 'ArrowDown'
-          ? Math.min(current + 1, lastIndex)
-          : Math.max(current - 1, 0)
-      })
+      const current = activeIndexRef.current
+      activate(!open ? selectedIndex : event.key === 'ArrowDown'
+        ? Math.min(current + 1, lastIndex)
+        : Math.max(current - 1, 0))
       return
     }
     if (open && (event.key === 'Home' || event.key === 'End')) {
       event.preventDefault()
-      setActiveIndex(event.key === 'Home' ? 0 : lastIndex)
+      activate(event.key === 'Home' ? 0 : lastIndex)
       return
     }
     if (event.key === 'Enter' || event.key === ' ') {
       event.preventDefault()
-      if (open) select(activeIndex)
-      else setOpen(true)
+      if (open) select(activeIndexRef.current)
+      else {
+        activate(selectedIndex)
+        setOpen(true)
+      }
       return
     }
     if (event.key === 'Escape' && open) {
@@ -88,7 +95,7 @@ export function PanelSelect({ ariaLabel, disabled = false, id, onChange, options
         aria-label={ariaLabel}
         disabled={unavailable}
         onClick={() => {
-          if (!open) setActiveIndex(selectedIndex)
+          if (!open) activate(selectedIndex)
           setOpen((current) => !current)
         }}
         onKeyDown={handleKeyDown}
@@ -107,7 +114,7 @@ export function PanelSelect({ ariaLabel, disabled = false, id, onChange, options
               aria-selected={option.value === value}
               key={option.value}
               onClick={() => select(index)}
-              onPointerEnter={() => setActiveIndex(index)}
+              onPointerEnter={() => activate(index)}
             >
               <span>{option.label}</span>
               {option.value === value && <Check size={14} aria-hidden="true" />}


### PR DESCRIPTION
## Summary
- use a synchronous active-option ref for keyboard selection
- ensure Enter/Space commit the latest Arrow/Home/End option even before React rerenders
- supersede the failed Float 0.4.3 release workflow with Float 0.4.4
- retain the notification-to-Web-inbox fix from 0.4.3

## Verification
- npm run check
- npm test (604)
- npm run build:extension
- extension smoke passed three consecutive runs

Float-only patch. Web/API remains 0.10.2. Chrome Web Store upload is excluded.